### PR TITLE
fixed incorrect syntax for loaders

### DIFF
--- a/src/content/concepts/loaders.md
+++ b/src/content/concepts/loaders.md
@@ -65,14 +65,14 @@ module.exports = {
       {
         test: /\.css$/,
         use: [
-          { loader: ['style-loader'](/loaders/style-loader) },
+          { loader: ['style-loader'] },
           {
-            loader: ['css-loader'](/loaders/css-loader),
+            loader: ['css-loader'],
             options: {
               modules: true
             }
           },
-          { loader: ['sass-loader'](/loaders/sass-loader) }
+          { loader: ['sass-loader'] }
         ]
       }
     ]


### PR DESCRIPTION
the syntax for loaders is incorrect, it shows incorrectly at https://webpack.js.org/concepts/loaders/ right now. My best guess is that it was done for linking to other markdown files but not sure about that. So deleted the additional words.

- [X] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [X] Make sure your PR complies with the [writer's guide][2].
- [X] Review the diff carefully as sometimes this can reveal issues.